### PR TITLE
Fix integration bugs found with swapclaw

### DIFF
--- a/src/opensage_acp/server.py
+++ b/src/opensage_acp/server.py
@@ -6,7 +6,7 @@ Architecture:
 
 For each ACP session the agent:
   1. Allocates a port from the configured range.
-  2. Optionally generates a per-session TOML config (MCP injection: Phase 2).
+  2. Generates a per-session TOML config (with MCP server injection).
   3. Spawns ``opensage web <agent_dir> --port <port> --session-id <id>``.
   4. Waits for the process to pass a health check.
   5. Creates an ``OpenSageHttpBridge`` pointing at it.
@@ -54,6 +54,7 @@ from acp.schema import (
     McpServerStdio,
     ResourceContentBlock,
     ResumeSessionResponse,
+    SessionCapabilities,
     SessionInfo,
     SseMcpServer,
     TextContentBlock,
@@ -136,7 +137,10 @@ class OpenSageACPAgent:
         log.debug("initialize: protocol_version=%d", protocol_version)
         return InitializeResponse(
             protocol_version=protocol_version,
-            agent_capabilities=AgentCapabilities(),
+            agent_capabilities=AgentCapabilities(
+                load_session=True,
+                session_capabilities=SessionCapabilities(list={}),
+            ),
         )
 
     async def new_session(
@@ -158,7 +162,8 @@ class OpenSageACPAgent:
             session = _Session(bridge=bridge, process=None, port=None, cwd=cwd)
         else:
             port = self._alloc_port()
-            process = self._spawn_opensage_web(session_id, port, mcp_servers)
+            config_path = self._generate_config(session_id, mcp_servers)
+            process = self._spawn_opensage_web(session_id, port, config_path=config_path)
             base_url = f"http://127.0.0.1:{port}"
             bridge = OpenSageHttpBridge(
                 base_url=base_url,
@@ -204,12 +209,12 @@ class OpenSageACPAgent:
         # Check for disk snapshot
         session_dir = _session_dir(session_id)
         if not Path(session_dir).exists():
-            log.debug("load_session: %s not found (no disk snapshot)", session_id)
-            return None
+            raise RequestError(-32602, f"Session not found: {session_id}")
 
         # Resume from disk: spawn opensage-web with --resume
         port = self._alloc_port()
-        process = self._spawn_opensage_web(session_id, port, mcp_servers, resume=True)
+        config_path = self._generate_config(session_id, mcp_servers)
+        process = self._spawn_opensage_web(session_id, port, config_path=config_path, resume=True)
         base_url = f"http://127.0.0.1:{port}"
         bridge = OpenSageHttpBridge(
             base_url=base_url,
@@ -311,7 +316,7 @@ class OpenSageACPAgent:
         for block in prompt:
             if isinstance(block, TextContentBlock):
                 parts.append(block.text)
-        task = " ".join(parts).strip() or "(no text)"
+        task = "".join(parts).strip() or "(no text)"
 
         log.debug("prompt: session_id=%s task=%r", session_id, task[:80])
 
@@ -324,11 +329,6 @@ class OpenSageACPAgent:
             raise RequestError(
                 -32603, f"opensage-web process died (exit code {session.process.returncode})"
             )
-
-        # Check for a cancel that arrived before we started
-        if session_id in self._cancelled:
-            self._cancelled.discard(session_id)
-            return PromptResponse(stop_reason="cancelled")
 
         try:
             async for chunk in session.bridge.run_sse(task):
@@ -459,17 +459,15 @@ class OpenSageACPAgent:
         self,
         session_id: str,
         port: int,
-        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None,
         *,
+        config_path: str | None = None,
         resume: bool = False,
     ) -> subprocess.Popen[bytes]:
         """Spawn an ``opensage web`` subprocess for this session.
 
         If *resume* is True, adds ``--resume`` to restart from a disk snapshot.
-
-        MCP server injection into the config is Phase 2 work; for now we pass
-        the template config path (if configured) directly.  A warning is logged
-        if MCP servers are supplied but cannot yet be injected.
+        If *config_path* is given, it is passed as ``--config`` to opensage-web;
+        otherwise, the global template (if configured) is used as a fallback.
         """
         cmd: list[str] = [
             self._config.opensage_command,
@@ -484,15 +482,10 @@ class OpenSageACPAgent:
         ]
         if resume:
             cmd.append("--resume")
-        if self._config.opensage_config_template:
+        if config_path:
+            cmd += ["--config", config_path]
+        elif self._config.opensage_config_template:
             cmd += ["--config", self._config.opensage_config_template]
-
-        if mcp_servers:
-            log.warning(
-                "new_session: %d MCP server(s) provided but MCP TOML injection is "
-                "not yet implemented (Phase 2).  MCP servers will be ignored.",
-                len(mcp_servers),
-            )
 
         log.info("spawning: %s", shlex.join(cmd))
         return subprocess.Popen(

--- a/src/opensage_acp/server.py
+++ b/src/opensage_acp/server.py
@@ -55,8 +55,8 @@ from acp.schema import (
     ResourceContentBlock,
     ResumeSessionResponse,
     SessionCapabilities,
-    SessionListCapabilities,
     SessionInfo,
+    SessionListCapabilities,
     SseMcpServer,
     TextContentBlock,
 )

--- a/src/opensage_acp/server.py
+++ b/src/opensage_acp/server.py
@@ -55,6 +55,7 @@ from acp.schema import (
     ResourceContentBlock,
     ResumeSessionResponse,
     SessionCapabilities,
+    SessionListCapabilities,
     SessionInfo,
     SseMcpServer,
     TextContentBlock,
@@ -139,7 +140,7 @@ class OpenSageACPAgent:
             protocol_version=protocol_version,
             agent_capabilities=AgentCapabilities(
                 load_session=True,
-                session_capabilities=SessionCapabilities(list={}),
+                session_capabilities=SessionCapabilities(list=SessionListCapabilities()),
             ),
         )
 

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -313,7 +313,7 @@ async def test_spawn_command_includes_agent_dir() -> None:
         return MagicMock()
 
     with patch("subprocess.Popen", side_effect=fake_popen):
-        agent._spawn_opensage_web("sess-abc", 9000, None)
+        agent._spawn_opensage_web("sess-abc", 9000)
 
     assert len(captured_cmds) == 1
     cmd = captured_cmds[0]
@@ -341,7 +341,7 @@ async def test_spawn_command_includes_config_template() -> None:
         return MagicMock()
 
     with patch("subprocess.Popen", side_effect=fake_popen):
-        agent._spawn_opensage_web("sess-xyz", 9001, None)
+        agent._spawn_opensage_web("sess-xyz", 9001)
 
     cmd = captured_cmds[0]
     assert "--config" in cmd
@@ -365,7 +365,7 @@ async def test_spawn_command_omits_config_when_not_set() -> None:
         return MagicMock()
 
     with patch("subprocess.Popen", side_effect=fake_popen):
-        agent._spawn_opensage_web("sess-noc", 9002, None)
+        agent._spawn_opensage_web("sess-noc", 9002)
 
     cmd = captured_cmds[0]
     assert "--config" not in cmd

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from acp.exceptions import RequestError
 
 from opensage_acp.config import Config
 from opensage_acp.server import OpenSageACPAgent
@@ -132,19 +133,19 @@ async def test_new_session_stores_session_dir():
 
 
 @pytest.mark.asyncio
-async def test_load_session_returns_none_for_unknown():
+async def test_load_session_raises_for_unknown():
     agent = OpenSageACPAgent(config=_echo_config())
-    result = await agent.load_session(cwd="/tmp", session_id="no-such")
-    assert result is None
+    with pytest.raises(RequestError):
+        await agent.load_session(cwd="/tmp", session_id="no-such")
 
 
 @pytest.mark.asyncio
-async def test_load_session_returns_none_when_no_disk_snapshot():
-    """T-09b: No in-memory session and no disk snapshot → returns None."""
+async def test_load_session_raises_when_no_disk_snapshot():
+    """T-09b: No in-memory session and no disk snapshot → raises RequestError."""
     config = Config(echo_mode=False)
     agent = OpenSageACPAgent(config=config)
-    result = await agent.load_session(cwd="/tmp", session_id="nonexistent-session-id-12345")
-    assert result is None
+    with pytest.raises(RequestError):
+        await agent.load_session(cwd="/tmp", session_id="nonexistent-session-id-12345")
 
 
 @pytest.mark.asyncio
@@ -681,7 +682,7 @@ async def test_prompt_non_text_blocks_only_sends_no_text():
 
 
 @pytest.mark.asyncio
-async def test_prompt_joins_multiple_text_blocks_with_space():
+async def test_prompt_joins_multiple_text_blocks_without_separator():
     agent = OpenSageACPAgent(config=_echo_config())
     conn = _make_mock_conn()
     agent.on_connect(conn)
@@ -702,21 +703,26 @@ async def test_prompt_joins_multiple_text_blocks_with_space():
         prompt=[_make_text_block("hello"), _make_text_block("world")],
         session_id=sid,
     )
-    assert captured == ["hello world"]
+    assert captured == ["helloworld"]
 
 
 @pytest.mark.asyncio
-async def test_prompt_pre_cancel_returns_cancelled():
+async def test_prompt_stale_cancel_does_not_poison_next_prompt():
+    """A stale cancel flag is consumed mid-stream, not before the prompt starts."""
     agent = OpenSageACPAgent(config=_echo_config())
     conn = _make_mock_conn()
     agent.on_connect(conn)
     sid = await _setup_session(agent)
 
-    # Pre-cancel before calling prompt
+    # Stale cancel flag set before calling prompt — mid-stream check picks it up
     agent._cancelled.add(sid)
 
     resp = await agent.prompt(prompt=[_make_text_block("go")], session_id=sid)
     assert resp.stop_reason == "cancelled"
+
+    # A second prompt should NOT be poisoned
+    resp2 = await agent.prompt(prompt=[_make_text_block("hello")], session_id=sid)
+    assert resp2.stop_reason == "end_turn"
 
 
 # ---------------------------------------------------------------------------
@@ -833,7 +839,7 @@ async def test_spawn_includes_host_flag():
 
     with patch("opensage_acp.server.subprocess.Popen") as mock_popen:
         mock_popen.return_value = MagicMock()
-        agent._spawn_opensage_web("sid", 8100, None)
+        agent._spawn_opensage_web("sid", 8100)
 
         cmd = mock_popen.call_args.args[0]
         assert "--host" in cmd
@@ -1251,20 +1257,17 @@ async def test_session_cleanup_tolerates_missing_config_dir():
 
 
 @pytest.mark.asyncio
-async def test_spawn_logs_warning_for_mcp_servers(caplog):
-    import logging
+async def test_spawn_uses_config_path_kwarg():
+    """_spawn_opensage_web passes config_path as --config when provided."""
     from unittest.mock import patch
-
-    from acp.schema import McpServerStdio
 
     config = Config(echo_mode=False, agent_dir="/test/agents")
     agent = OpenSageACPAgent(config=config)
 
-    mcp = McpServerStdio(command="echo", args=["hi"], env=[], name="test-mcp")
-
     with patch("opensage_acp.server.subprocess.Popen") as mock_popen:
         mock_popen.return_value = MagicMock()
-        with caplog.at_level(logging.WARNING):
-            agent._spawn_opensage_web("sid", 8100, [mcp])
+        agent._spawn_opensage_web("sid", 8100, config_path="/tmp/test-config.toml")
 
-    assert any("MCP" in record.message for record in caplog.records)
+        cmd = mock_popen.call_args.args[0]
+        assert "--config" in cmd
+        assert "/tmp/test-config.toml" in cmd


### PR DESCRIPTION
## Summary
- Advertise loadSession and list capabilities in AgentCapabilities (#3)
- Remove stale cancel pre-check that poisoned next prompt (#5)
- Return error instead of empty success for unknown load_session (#6)
- Wire _generate_config into new_session/load_session for MCP injection (#7)
- Fix multi-block prompt text joining to use empty separator (#8)

## Test plan
- [ ] Existing test suite passes
- [ ] Integration tests with swapclaw pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)